### PR TITLE
Fix wrong regex

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -130,7 +130,7 @@ prepare() {
   # Install specified products if partialinstall is set to 'true'.
   if [ "${partialinstall}" = 'true' ]; then
     for _prod in "${products[@]}"; do
-      sed -i 's|^#\(product.'"${_prod}"'\)|\1|' "${_set}"
+      sed -i 's|^#\(product.'"${_prod}"'\)$|\1|' "${_set}"
     done
   fi
 


### PR DESCRIPTION
Without the dollar sign, when `partialinstall` is `true` and `MATLAB`, the regex will uncomment all products starting with `MATLAB`, including `MATLAB_Coder` and so on and so on.